### PR TITLE
Automate chocolatey release

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -15,6 +15,7 @@ variables:
   containerRegistry: 'nudelsiebacr.azurecr.io'
   dockerfilePath: '$(Build.SourcesDirectory)/src/Nudelsieb/Nudelsieb.WebApi/Dockerfile'
   version: '0.0.2.$(Build.BuildId)'
+  chocolateyArtifactName: 'choco-nupkg-drop'
   
   # Agent VM image name
   vmImageName: 'ubuntu-latest'
@@ -62,20 +63,23 @@ stages:
     - task: PowerShell@2
       name: BuildChocoPackage
       inputs:
-        filePath: '$(System.DefaultWorkingDirectory)\build\cli\build-self-contained.ps1'
+        filePath: '$(System.DefaultWorkingDirectory)/build/cli/build-self-contained.ps1'
         arguments: '-Version $(version) -OutputPath $(Build.ArtifactStagingDirectory)'
     - task: PublishBuildArtifacts@1
       inputs:
-        ArtifactName: choco-drop
+        ArtifactName: $(chocolateyArtifactName)
         PathtoPublish: $(Build.ArtifactStagingDirectory)
   - deployment: PublishCli
     environment: Production
     dependsOn: InstallPrerequisits
     strategy:
-     runOnce:
-       deploy:
-         steps:
-           - task: PowerShell@2
-             inputs:
-               targetType: inline
-               script: 'choco push "./nudelsieb-cli.$(version).nupkg" --source https://push.chocolatey.org --apikey  $(ChocolateyApiKey)'
+      runOnce:
+        deploy:
+          steps:
+            - task: PowerShell@2
+              inputs:
+                targetType: inline
+                script: >-
+                  choco push "$(Pipeline.Workspace)/$(chocolateyArtifactName)/nudelsieb-cli.$(version).nupkg"
+                  --source https://push.chocolatey.org 
+                  --apikey  $(ChocolateyApiKey)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -38,18 +38,19 @@ stages:
         Dockerfile: '$(Build.SourcesDirectory)/src/Nudelsieb/Nudelsieb.WebApi/Dockerfile'
         buildContext: '$(Build.SourcesDirectory)/src/Nudelsieb'
         tags: '$(version)'
-- stage: Publish
+- stage: PublishWebApi
   dependsOn: BuildWebApi
   jobs:
   - job: Publish
     steps:
     - task: AzureWebAppContainer@1
       inputs:
-        azureSubscription: 'Visual Studio Enterprise – MPN(c82af33e-d706-46fc-af9d-96e2d14d5c74)'
+        azureSubscription: 'nudelsieb-service-connection'
         appName: 'nudelsieb'
         containers: '$(containerRegistry)/$(imageRepository):$(version)'
 - stage: BuildCli
-  pool: $(windowsVmImageName)
+  pool:
+    vmImage: $(windowsVmImageName)
   jobs:
   - job: InstallPrerequisits
     steps:
@@ -58,14 +59,23 @@ stages:
       inputs:
         packageType: 'sdk'
         version: '3.1.x'
+    - task: PowerShell@2
+      name: BuildChocoPackage
+      inputs:
+        filePath: '$(System.DefaultWorkingDirectory)\build\cli\build-self-contained.ps1'
+        arguments: '-Version $(version) -OutputPath $(Build.ArtifactStagingDirectory)'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        ArtifactName: choco-drop
+        PathtoPublish: $(Build.ArtifactStagingDirectory)
   - deployment: PublishCli
     environment: Production
+    dependsOn: InstallPrerequisits
     strategy:
      runOnce:
        deploy:
          steps:
            - task: PowerShell@2
              inputs:
-               filePath: './build/cli/build-self-contained.ps1'
-               arguments: '-Version $(version) -Publish=$true'
-               workingDirectory: './build/cli/'
+               targetType: inline
+               script: 'choco push "./nudelsieb-cli.$(version).nupkg" --source https://push.chocolatey.org --apikey  $(ChocolateyApiKey)'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -14,13 +14,14 @@ variables:
   imageRepository: 'nudelsieb-webapi'
   containerRegistry: 'nudelsiebacr.azurecr.io'
   dockerfilePath: '$(Build.SourcesDirectory)/src/Nudelsieb/Nudelsieb.WebApi/Dockerfile'
-  tag: '$(Build.BuildId)'
+  version: '0.0.2.$(Build.BuildId)'
   
   # Agent VM image name
   vmImageName: 'ubuntu-latest'
+  windowsVmImageName: 'windows-latest'
 
 stages:
-- stage: Build
+- stage: BuildWebApi
   displayName: Build and push stage
   jobs:  
   - job: Build
@@ -36,8 +37,9 @@ stages:
         command: 'buildAndPush'
         Dockerfile: '$(Build.SourcesDirectory)/src/Nudelsieb/Nudelsieb.WebApi/Dockerfile'
         buildContext: '$(Build.SourcesDirectory)/src/Nudelsieb'
-        tags: '$(tag)'
+        tags: '$(version)'
 - stage: Publish
+  dependsOn: BuildWebApi
   jobs:
   - job: Publish
     steps:
@@ -45,4 +47,24 @@ stages:
       inputs:
         azureSubscription: 'Visual Studio Enterprise – MPN(c82af33e-d706-46fc-af9d-96e2d14d5c74)'
         appName: 'nudelsieb'
-        containers: '$(containerRegistry)/$(imageRepository):$(tag)'
+        containers: '$(containerRegistry)/$(imageRepository):$(version)'
+- stage: BuildCli
+  pool: $(windowsVmImageName)
+  jobs:
+  - job: InstallPrerequisits
+    steps:
+    - task: ChocolateyToolInstaller@0
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        version: '3.1.x'
+  - deployment: PublishCli
+    strategy:
+     runOnce:
+       deploy:
+         steps:
+           - task: PowerShell@2
+             inputs:
+               filePath: './build/cli/build-self-contained.ps1'
+               arguments: '-Version $(version) -Publish=$true'
+               workingDirectory: './build/cli/'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -22,16 +22,16 @@ variables:
   windowsVmImageName: 'windows-latest'
 
 stages:
-- stage: BuildWebApi
-  displayName: Build and push stage
+- stage: BuildAndPushWebApiContainer
+  displayName: 'Web API: Build and push Docker image'
   jobs:  
   - job: Build
-    displayName: Build
+    displayName: Build and push Docker image
     pool:
       vmImage: $(vmImageName)
     steps:
     - task: Docker@2
-      displayName: Build and push an image to container registry
+      displayName: Build and push an image to the container registry
       inputs:
         containerRegistry: '$(dockerRegistryServiceConnection)'
         repository: '$(imageRepository)'
@@ -40,7 +40,8 @@ stages:
         buildContext: '$(Build.SourcesDirectory)/src/Nudelsieb'
         tags: '$(version)'
 - stage: PublishWebApi
-  dependsOn: BuildWebApi
+  displayName: Update Docker image in Azure App Service
+  dependsOn: BuildAndPushWebApiContainer
   jobs:
   - job: Publish
     steps:
@@ -49,19 +50,20 @@ stages:
         azureSubscription: 'nudelsieb-service-connection'
         appName: 'nudelsieb'
         containers: '$(containerRegistry)/$(imageRepository):$(version)'
-- stage: BuildCli
+- stage: ReleaseCliToChocolatey
+  displayName: 'CLI: Release to Chocolatey'
   pool:
     vmImage: $(windowsVmImageName)
   jobs:
-  - job: InstallPrerequisits
-    steps:
+  - job: CreatePackage
+    steps: 
     - task: ChocolateyToolInstaller@0
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
         version: '3.1.x'
     - task: PowerShell@2
-      name: BuildChocoPackage
+      name: BuildAndPackageBinaries
       inputs:
         filePath: '$(System.DefaultWorkingDirectory)/build/cli/build-self-contained.ps1'
         arguments: '-Version $(version) -OutputPath $(Build.ArtifactStagingDirectory)'
@@ -69,9 +71,9 @@ stages:
       inputs:
         ArtifactName: $(chocolateyArtifactName)
         PathtoPublish: $(Build.ArtifactStagingDirectory)
-  - deployment: PublishCli
+  - deployment: PushCliPackageToChocolatey
     environment: Production
-    dependsOn: InstallPrerequisits
+    dependsOn: CreatePackage
     strategy:
       runOnce:
         deploy:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -59,6 +59,7 @@ stages:
         packageType: 'sdk'
         version: '3.1.x'
   - deployment: PublishCli
+    environment: Production
     strategy:
      runOnce:
        deploy:

--- a/build/cli/build-self-contained.ps1
+++ b/build/cli/build-self-contained.ps1
@@ -13,7 +13,7 @@ Param(
 Write-Host "Building version $Version"
 
 rmdir $PSScriptRoot/chocolatey/tools/win-x64/* -Force -Recurse -ErrorAction SilentlyContinue
-dotnet publish --configuration Release --runtime win-x64 --output $PSScriptRoot/chocolatey/tools/win-x64 --self-contained true -p:AssemblyVersion=$Version -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None --verbosity minimal $PSScriptRoot/../../src/Nudelsieb/Nudelsieb.Cli/Nudelsieb.Cli.csproj
+dotnet publish --configuration Release --runtime win-x64 --output $PSScriptRoot/chocolatey/tools/win-x64 --self-contained true -p:AssemblyVersion=$Version -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true  -p:PublishTrimmed=true -p:DebugType=None --verbosity minimal $PSScriptRoot/../../src/Nudelsieb/Nudelsieb.Cli/Nudelsieb.Cli.csproj
 
 choco pack --version $Version --outputdirectory $OutputPath $PSScriptRoot/chocolatey/nudelsieb-cli.nuspec
 

--- a/build/cli/build-self-contained.ps1
+++ b/build/cli/build-self-contained.ps1
@@ -12,12 +12,12 @@ Param(
 
 Write-Host "Building version $Version"
 
-rmdir ./chocolatey/tools/win-x64/* | Out-Null
+rmdir ./chocolatey/tools/win-x64/* -Force -Recurse -ErrorAction SilentlyContinue
 dotnet publish --configuration Release --runtime win-x64 --output ./chocolatey/tools/win-x64 --self-contained true -p:AssemblyVersion=$Version -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None --verbosity minimal ./../../src/Nudelsieb/Nudelsieb.Cli/Nudelsieb.Cli.csproj
 
 choco pack --version $Version --outputdirectory $OutputPath ./chocolatey/nudelsieb-cli.nuspec
 
-choco uninstall nudelsieb-cli | Out-Null
+choco uninstall nudelsieb-cli -ErrorAction SilentlyContinue
 
 mkdir -f $OutputPath # -f to suppress error when already existing
 

--- a/build/cli/build-self-contained.ps1
+++ b/build/cli/build-self-contained.ps1
@@ -7,10 +7,7 @@ Param(
     $OutputPath="./publish",
     [Parameter()]
     [Bool]
-    $Publish=$false,
-    [Parameter()]
-    [Bool]
-    $Verbose=$false
+    $Publish=$false
 )
 
 Write-Host "Building version $Version"
@@ -22,6 +19,8 @@ choco pack --version $Version --outputdirectory $OutputPath ./chocolatey/nudelsi
 
 choco uninstall nudelsieb-cli | Out-Null
 
+mkdir -f $OutputPath # -f to suppress error when already existing
+
 if ($Verbose) {
     # using -dv for debug and verbose output
     choco install -s -dv $OutputPath nudelsieb-cli 
@@ -29,7 +28,9 @@ if ($Verbose) {
     choco install -s $OutputPath nudelsieb-cli
 }
 
+nudelsieb --version
+
 if ($Publish) {
-    mkdir -f $OutputPath # -f to suppress error when already existing
+    # only for publishing from local dev environment
     choco push "./$OutputPath/nudelsieb-cli.$($Version).nupkg" --source https://push.chocolatey.org
 }

--- a/build/cli/build-self-contained.ps1
+++ b/build/cli/build-self-contained.ps1
@@ -28,8 +28,6 @@ if ($Verbose) {
     choco install -s $OutputPath nudelsieb-cli
 }
 
-nudelsieb --version
-
 if ($Publish) {
     # only for publishing from local dev environment
     choco push "$OutputPath/nudelsieb-cli.$($Version).nupkg" --source https://push.chocolatey.org

--- a/build/cli/build-self-contained.ps1
+++ b/build/cli/build-self-contained.ps1
@@ -12,12 +12,12 @@ Param(
 
 Write-Host "Building version $Version"
 
-rmdir ./chocolatey/tools/win-x64/* -Force -Recurse -ErrorAction SilentlyContinue
-dotnet publish --configuration Release --runtime win-x64 --output ./chocolatey/tools/win-x64 --self-contained true -p:AssemblyVersion=$Version -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None --verbosity minimal ./../../src/Nudelsieb/Nudelsieb.Cli/Nudelsieb.Cli.csproj
+rmdir $PSScriptRoot/chocolatey/tools/win-x64/* -Force -Recurse -ErrorAction SilentlyContinue
+dotnet publish --configuration Release --runtime win-x64 --output $PSScriptRoot/chocolatey/tools/win-x64 --self-contained true -p:AssemblyVersion=$Version -p:PublishReadyToRun=true -p:PublishTrimmed=true -p:DebugType=None --verbosity minimal $PSScriptRoot/../../src/Nudelsieb/Nudelsieb.Cli/Nudelsieb.Cli.csproj
 
-choco pack --version $Version --outputdirectory $OutputPath ./chocolatey/nudelsieb-cli.nuspec
+choco pack --version $Version --outputdirectory $OutputPath $PSScriptRoot/chocolatey/nudelsieb-cli.nuspec
 
-choco uninstall nudelsieb-cli -ErrorAction SilentlyContinue
+choco uninstall nudelsieb-cli | Out-Null
 
 mkdir -f $OutputPath # -f to suppress error when already existing
 
@@ -32,5 +32,5 @@ nudelsieb --version
 
 if ($Publish) {
     # only for publishing from local dev environment
-    choco push "./$OutputPath/nudelsieb-cli.$($Version).nupkg" --source https://push.chocolatey.org
+    choco push "$OutputPath/nudelsieb-cli.$($Version).nupkg" --source https://push.chocolatey.org
 }


### PR DESCRIPTION
Extends the Azure pipeline with build and release definitions that publish the CLI as a chocolatey package.