### PR TITLE
Sign the Android APK

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -100,8 +100,6 @@ stages:
   displayName: 'Build the Android app'
   variables: 
     - group: 'android-variables'
-    - name: 'keystore-file' # see Secure Files in Pipelines Libary
-      value: 'nudelsieb.keystore'
   dependsOn: []
   jobs:
     - job: BuildXamarin
@@ -129,7 +127,7 @@ stages:
       - task: AndroidSigning@3
         inputs:
           apkFiles: '$(Build.ArtifactStagingDirectory)/android/*.apk'
-          apksignerKeystoreFile: '$(keystore-file)'
+          apksignerKeystoreFile: 'nudelsieb.keystore'
           apksignerKeystorePassword: '$(keystore-password)'
           apksignerKeystoreAlias: 'nudelsieb'
       - task: PublishPipelineArtifact@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -98,6 +98,10 @@ stages:
                 --apikey  $(ChocolateyApiKey)
 - stage: AndroidApp
   displayName: 'Build the Android app'
+  variables: 
+    - group: 'android-variables'
+    - name: 'keystore-file' # see Secure Files in Pipelines Libary
+      value: 'nudelsieb.keystore'
   dependsOn: []
   jobs:
     - job: BuildXamarin
@@ -122,6 +126,12 @@ stages:
           msbuildVersionOption: '16.0'
           msbuildArguments: '/p:GoogleServicesJsonFilePath=$(googleServicesFile.secureFilePath)'
           jdkOption: 'JDKVersion'
+      - task: AndroidSigning@3
+        inputs:
+          apkFiles: '$(Build.ArtifactStagingDirectory)/android/*.apk'
+          apksignerKeystoreFile: '$(keystore-file)'
+          apksignerKeystorePassword: '$(keystore-password)'
+          apksignerKeystoreAlias: 'nudelsieb'
       - task: PublishPipelineArtifact@1
         inputs:
           targetPath: '$(Build.ArtifactStagingDirectory)/android'

--- a/src/Nudelsieb/Nudelsieb.Mobile/Nudelsieb.Mobile.Android/Nudelsieb.Mobile.Android.csproj
+++ b/src/Nudelsieb/Nudelsieb.Mobile/Nudelsieb.Mobile.Android/Nudelsieb.Mobile.Android.csproj
@@ -23,6 +23,8 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidManifestPlaceholders>identityClientId=6ea4a837-1b3b-483f-aaeb-e7a96d56d4d9</AndroidManifestPlaceholders>
+    <!-- IntermediateOutputPath fixes MAX_PATH length issue when building an archive locally: -->
+    <IntermediateOutputPath>C:/nds</IntermediateOutputPath>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -37,7 +39,6 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <MandroidI18n />
     <AndroidSupportedAbis />
-    <AndroidKeyStore>false</AndroidKeyStore>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
@@ -50,6 +51,7 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AndroidLinkTool>r8</AndroidLinkTool>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <AndroidKeyStore>false</AndroidKeyStore>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />


### PR DESCRIPTION
- Fix MAX_PATH length issue when building an archive locally
- Sign built APK in pipeline
- Download keystore as Secure File
