### PR TITLE
Fix backend notification service using invalid tag

### DIFF
--- a/src/Nudelsieb/Nudelsieb.Notifications/Notifyer/AndroidNotifyer.cs
+++ b/src/Nudelsieb/Nudelsieb.Notifications/Notifyer/AndroidNotifyer.cs
@@ -94,6 +94,6 @@ namespace Nudelsieb.Notifications.Notifyer
         /// An installation for the Notifications Hub automatically creates a tag for the defined user id.
         /// Example tag: $UserId:{93fab134-e9ed-4a73-a106-ba6fa15f7f20}
         /// </summary>
-        private string GetTagForUserId(Guid userId) => $"$UserId:{userId}";
+        private string GetTagForUserId(Guid userId) => "$UserId:{" + userId + "}";
     }
 }


### PR DESCRIPTION
The tag's value must be put into curly braces, see: https://github.com/MicrosoftDocs/azure-docs/issues/18460#issuecomment-450544448
